### PR TITLE
Use SafeArea for iOS so ErrorPage and Close button are well positioned

### DIFF
--- a/XAMLator.Server/ErrorPage.xaml
+++ b/XAMLator.Server/ErrorPage.xaml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="XAMLator.Server.ErrorPage">
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core" 
+    ios:Page.UseSafeArea="true" 
+    x:Class="XAMLator.Server.ErrorPage">
     <ContentPage.Content>
         <StackLayout Spacing="0" VerticalOptions="Start">
             <AbsoluteLayout
@@ -15,7 +20,7 @@
                     HorizontalTextAlignment="Center"
                     VerticalTextAlignment="Center"
                     FontSize="30"
-                    Text="Preview error!"/>
+                    Text="Preview Error!"/>
                  <Button Margin="5" Text="Close" TextColor="White" Command="{Binding CloseCommand}"/>
             </AbsoluteLayout>
             <Label


### PR DESCRIPTION
Before:

<img width="584" alt="screenshot 2018-09-22 09 12 42" src="https://user-images.githubusercontent.com/41873/45918240-923a8980-be49-11e8-88f7-042eb7eaec93.png">

After:

<img width="584" alt="screenshot 2018-09-22 09 18 24" src="https://user-images.githubusercontent.com/41873/45918243-9797d400-be49-11e8-8bf3-27fc90ce4c9f.png">
